### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ More about: https://www.soenkeahrens.de/en/takesmartnotes
 ## Usage
 - Download the zip and unzip
 - Select the unzipped folder as a vault in Obsidian
-- Install Obidian community plugins: [Banners](https://github.com/noatpad/obsidian-banners), [Charts](https://github.com/phibr0/obsidian-charts) and [DataView](https://github.com/blacksmithgu/obsidian-dataview).
+- Install Obsidian community plugins: [Banners](https://github.com/noatpad/obsidian-banners), [Charts](https://github.com/phibr0/obsidian-charts) and [DataView](https://github.com/blacksmithgu/obsidian-dataview).
 - Read book from [Sönke Ahrens](https://www.soenkeahrens.de/en/takesmartnotes)
 - Explore Starter Kit
 - Learn to use [Obsidian-Templates for Zettelkasten](https://github.com/groepl/Obsidian-Templates?tab=readme-ov-file#list-of-templates)


### PR DESCRIPTION
Corrected a minor typo (‘obidian’ → ‘Obsidian’) in README.md.